### PR TITLE
Upgrade detekt version to one that doesn't depend on disappeared depndency.

### DIFF
--- a/.pre-commit-channel/detekt.json
+++ b/.pre-commit-channel/detekt.json
@@ -1,10 +1,9 @@
 {
   "mainClass" : "io.gitlab.arturbosch.detekt.cli.Main",
   "repositories": [
-    "central",
-    "https://kotlin.bintray.com/kotlinx"
+    "central"
   ],
   "dependencies": [
-    "io.gitlab.arturbosch.detekt:detekt-cli:1.14.2"
+    "io.gitlab.arturbosch.detekt:detekt-cli:1.18.0"
   ]
 }


### PR DESCRIPTION

See https://github.com/detekt/detekt/issues/3461 for backstory