### PR TITLE
Update versions for google-java-format-jdk11, detekt and ktlint

### DIFF
--- a/.pre-commit-channel/detekt.json
+++ b/.pre-commit-channel/detekt.json
@@ -4,6 +4,6 @@
     "central"
   ],
   "dependencies": [
-    "io.gitlab.arturbosch.detekt:detekt-cli:1.22.0"
+    "io.gitlab.arturbosch.detekt:detekt-cli:1.23.1"
   ]
 }

--- a/.pre-commit-channel/google-java-format-jdk11.json
+++ b/.pre-commit-channel/google-java-format-jdk11.json
@@ -3,6 +3,6 @@
     "central"
   ],
   "dependencies": [
-    "com.google.googlejavaformat:google-java-format:1.16.0"
+    "com.google.googlejavaformat:google-java-format:1.17.0"
   ]
 }

--- a/.pre-commit-channel/ktlint.json
+++ b/.pre-commit-channel/ktlint.json
@@ -5,6 +5,6 @@
     "central"
   ],
   "dependencies": [
-    "com.pinterest:ktlint:0.48.2"
+    "com.pinterest:ktlint:0.50.0"
   ]
 }


### PR DESCRIPTION
Hi, I would like to update the detekt and ktlint to the latest available versions